### PR TITLE
Update Tensorflow_introduction_new.ipynb: from reduce_mean to reduce_sum

### DIFF
--- a/C2 - Improving Deep Neural Networks Hyperparameter tuning, Regularization and Optimization/Week 3/Tensorflow_introduction_new.ipynb
+++ b/C2 - Improving Deep Neural Networks Hyperparameter tuning, Regularization and Optimization/Week 3/Tensorflow_introduction_new.ipynb
@@ -1202,7 +1202,7 @@
     "    #(1 line of code)\n",
     "    # cost = ...\n",
     "    # YOUR CODE STARTS HERE\n",
-    "    cost = tf.reduce_mean(tf.keras.metrics.categorical_crossentropy(tf.transpose(labels),tf.transpose(logits),from_logits=True))\n",
+    "    cost = tf.reduce_sum(tf.keras.metrics.categorical_crossentropy(tf.transpose(labels),tf.transpose(logits),from_logits=True))\n",
     "   \n",
     "    # YOUR CODE ENDS HERE\n",
     "    return cost"


### PR DESCRIPTION
Reduce_mean to be changed to reduce_sum for better results | Course 2 W3A1

To quote the notebook itself

"
In step 1, the compute_total_loss function will only take care of summing the losses from one mini-batch of samples. Then, as you train the model (in section 3.3) which will call this compute_total_loss function once per mini-batch, step 2 will be done by accumulating the sums from each of the mini-batches, and finishing it with the division by the total number of samples to get the final cost value.

Computing the "total loss" instead of "mean loss" in step 1 can make sure the final cost value to be consistent. For example, if the mini-batch size is 4 but there are just 5 samples in the whole batch, then the last mini-batch is going to have 1 sample only. Considering the 5 samples, losses to be [0, 1, 2, 3, 4] respectively, we know the final cost should be their average which is 2. Adopting the "total loss" approach will get us the same answer. However, the "mean loss" approach will first get us 1.5 and 4 for the two mini-batches, and then finally 2.75 after taking average of them, which is different from the desired result of 2. Therefore, the "total loss" approach is adopted here.

"