### PR TITLE
C2W1 Update Gradient Checking v1.ipynb

### DIFF
--- a/C2 - Improving Deep Neural Networks Hyperparameter tuning, Regularization and Optimization/Week 1/Gradient Checking/Gradient Checking v1.ipynb
+++ b/C2 - Improving Deep Neural Networks Hyperparameter tuning, Regularization and Optimization/Week 1/Gradient Checking/Gradient Checking v1.ipynb
@@ -488,7 +488,7 @@
    "source": [
     "# GRADED FUNCTION: gradient_check_n\n",
     "\n",
-    "def gradient_check_n(parameters, gradients, X, Y, epsilon = 1e-7):\n",
+    "def gradient_check_n(parameters, gradients, X, Y, epsilon = 1e-7, print_msg=False):\n",
     "    \"\"\"\n",
     "    Checks if backward_propagation_n computes correctly the gradient of the cost output by forward_propagation_n\n",
     "    \n",


### PR DESCRIPTION
The gradient_check_n function was missing the print_msg=False in the parameters which lead to the following error

TypeError: gradient_check_n() takes from 4 to 5 positional arguments but 6 were given

This is resolved by including print_msg=False in the function parameter thus making it the following:

def gradient_check_n(parameters, gradients, X, Y, epsilon=1e-7, print_msg=False):